### PR TITLE
New USB "Micromega MyDAC" entry to enable hw mixer.

### DIFF
--- a/srv/http/settings/i2s/MICROMEGA MYDAC
+++ b/srv/http/settings/i2s/MICROMEGA MYDAC
@@ -1,0 +1,5 @@
+sysname:MICROMEGA MYDAC
+extlabel:Micromega MyDAC
+mixer_control:MICROMEGA MYDAC USB Audio 2.0 Output Playba
+mixer_index:2
+type:usb

--- a/srv/http/settings/mpd-conf.sh
+++ b/srv/http/settings/mpd-conf.sh
@@ -35,11 +35,13 @@ for line in "${lines[@]}"; do
 	(( $aplaynameL > 1 )) && aplayname="$aplayname"-$(( ${device: -1} + 1 ))
 	name=$aplayname
 	mixer_control=
+	mixer_index=0
 	extlabel=
 	routecmd=
 	i2sfile="/srv/http/settings/i2s/$aplayname"
 	if [[ -e "$i2sfile" ]]; then
 		mixer_control=$( grep mixer_control "$i2sfile"  | cut -d: -f2- )
+		mixer_index=$( (grep mixer_index "$i2sfile" || echo ":0") | cut -d: -f2 )
 		extlabel=$( grep extlabel "$i2sfile"  | cut -d: -f2- )
 		[[ -n $extlabel ]] && name=$extlabel
 		routecmd=$( grep route_cmd "$i2sfile" | cut -d: -f2 )
@@ -58,6 +60,7 @@ audio_output {
 	if [[ -n $mixer_control ]]; then
 		mpdconf+='
 	mixer_control     "'$mixer_control'"
+	mixer_index       "'$mixer_index'"
 	mixer_device      "hw:'$card'"'
 	
 	fi


### PR DESCRIPTION
Added "mixer_index" entry to mpd.conf generator required
to select a volume mixer not at default index 0.

It's a DAC I bought several years ago. See https://micromega.com/en/products/my-range/mydac/ for details. I ran original RuneAudio system for a while on my RPi-2 (which I patched to support this DAC). Now that I upgraded it to Re2, I would like upstream support for it. So I hope you will accept this pull request (it's my first one on GitHub!).
Best regards and great work for the updated UI.